### PR TITLE
rsx: Support CSAA transparency without multiple rasterization samples…

### DIFF
--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -571,12 +571,13 @@ namespace glsl
 			// Lowers alpha accuracy down to 2 bits, to mimic A2C banding
 			// Alpha lower than the real threshold (e.g 0.25 for 4 samples) gets a randomized chance to make it to the lowest transparency state
 			// Helps to avoid A2C tested foliage disappearing in the distance
+			// TODO: Fix dithering when mipmap gather is finished to remove muddy appearance. Alpha boost is only present to hide far LOD issues in titles like RDR
 			OS <<
 			"bool coverage_test_passes(/*inout*/in vec4 _sample, uint control)\n"
 			"{\n"
 			"	if ((control & 0x1) == 0) return false;\n"
 			"\n"
-			"	float samples = ((control & 0x2) != 0)? 4.f : 2.f;\n"
+			"	float samples = float(control & 0x6) * 0.5f + 1.f;\n"
 			"	float hash    = _saturate(_rand(gl_FragCoord) + 0.5f) * 0.9f;\n"
 			"	float epsilon = hash / samples;\n"
 			"	float alpha   = trunc((_sample.a + epsilon) * samples) / samples;\n"

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -36,6 +36,7 @@ GLGSRender::GLGSRender() : GSRender()
 	else
 		m_vertex_cache = std::make_unique<gl::weak_vertex_cache>();
 
+	supports_hw_a2c = false;
 	supports_multidraw = true;
 	supports_native_ui = (bool)g_cfg.misc.use_native_interface;
 }
@@ -1516,6 +1517,12 @@ void GLGSRender::update_draw_state()
 	}
 
 	gl_state.front_face(front_face(rsx::method_registers.front_face_mode()));
+
+	// Sample control
+	// TODO: MinSampleShading
+	//gl_state.enable(rsx::method_registers.msaa_enabled(), GL_MULTISAMPLE);
+	//gl_state.enable(rsx::method_registers.msaa_alpha_to_coverage_enabled(), GL_SAMPLE_ALPHA_TO_COVERAGE);
+	//gl_state.enable(rsx::method_registers.msaa_alpha_to_one_enabled(), GL_SAMPLE_ALPHA_TO_ONE);
 
 	//TODO
 	//NV4097_SET_ANISO_SPREAD

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -421,8 +421,9 @@ namespace rsx
 		s32 m_skip_frame_ctr = 0;
 		bool skip_frame = false;
 
-		bool supports_multidraw = false;
-		bool supports_native_ui = false;
+		bool supports_multidraw = false;  // Draw call batching
+		bool supports_native_ui = false;  // Native UI rendering
+		bool supports_hw_a2c = false;     // Alpha to coverage
 
 		// FIFO
 		std::unique_ptr<FIFO::FIFO_control> fifo_ctrl;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -575,6 +575,9 @@ VKGSRender::VKGSRender() : GSRender()
 
 	supports_multidraw = true;
 	supports_native_ui = (bool)g_cfg.misc.use_native_interface;
+	// NOTE: We do not actually need multiple sample support for A2C to work
+	// This is here for visual consistency - will be removed when AA problems due to mipmaps are fixed
+	supports_hw_a2c = (g_cfg.video.antialiasing_level != msaa_level::none);
 }
 
 VKGSRender::~VKGSRender()
@@ -2552,7 +2555,7 @@ bool VKGSRender::load_program()
 	}
 
 	const auto rasterization_samples = u8((m_current_renderpass_key >> 16) & 0xF);
-	if (rasterization_samples > 1)
+	if (supports_hw_a2c || rasterization_samples > 1)
 	{
 		properties.state.set_multisample_state(
 			rasterization_samples,


### PR DESCRIPTION
… enabled